### PR TITLE
Using a lambda expression to inline imports

### DIFF
--- a/src/inlined.py
+++ b/src/inlined.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+sort = (lambda repeat=__import__("itertools").repeat, shuffle=__import__("random").shuffle: lambda lst: next(lst for _ in repeat(None) if shuffle(lst) or (all(lst[i] <= lst[i+1] for i in range(len(lst)-1)))))()

--- a/src/test.py
+++ b/src/test.py
@@ -1,6 +1,18 @@
 #!/usr/bin/python
 import bogo1
+import inlined
 import random
-lst = [random.randrange(-5,5) for i in range(5)]
-lst = bogo1.sort(lst)
-print(lst)
+import sys
+
+TESTS = 500
+
+for _ in range(TESTS):
+    for mod in inlined, bogo1:
+        lst = [random.randrange(-5,5) for i in range(5)]
+        mod.sort(lst)
+        if "-v" in sys.argv:
+            print(mod.__name__, lst)
+        if sorted(lst) != lst:
+            sys.exit("Testing failed - {} produced {}".format(mod, lst))
+else:
+    print("Testing passed")


### PR DESCRIPTION
Added a new script that uses default arguments and `__import__` for ad-hoc  module importing, to make a true one-liner. It uses the same algorithm and approach. The original, readable `bogo1` is still present. Also expanded `test` a little.